### PR TITLE
Update docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm install
 
       - name: Build JSDoc
-        run: npm run docs
+        run: npx jsdoc -c jsdoc.json -d ./specs/docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Previous Build JSDoc run line didn't generate files into ./docs/ . Our documents are in /scripts/docs, so replaced run line with "npx jsdoc -c jsdoc.json -d ./specs/docs"

## Summary
Merge failed for sprint review doc upload

## Related Issues / Tickets

## Changes Introduced
Changes yaml file to correct docs path

## Testing Instructions
Try remerging spring docs

**Expected Result:**
Merge should be fixed

## Screenshots / Demos (if applicable)
N/A

## Deployment Notes
N/A

## Additional Context
N/A

