### PR TITLE
42 Group Directory Page Implementation

### DIFF
--- a/frontend/css/pages/directory/group-directory.css
+++ b/frontend/css/pages/directory/group-directory.css
@@ -1,0 +1,468 @@
+/**
+ * Group Directory Page Styles
+ * Displays a paginated grid of group/team cards
+ */
+
+/* ========================================
+   GLOBAL STYLES
+   ======================================== */
+
+/* CSS Reset */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 1.5;
+  color: #333;
+  background: #f5f5f5;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Navigation */
+.main-nav {
+  background: #1967d2;
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.nav-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-brand a {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  gap: 2rem;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.nav-links a:hover {
+  opacity: 0.8;
+}
+
+/* Main Content */
+main {
+  flex: 1;
+  padding: 2rem 0;
+}
+
+/* Footer */
+.main-footer {
+  background: #fff;
+  border-top: 1px solid #e0e0e0;
+  padding: 2rem;
+  margin-top: auto;
+}
+
+.footer-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  text-align: center;
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* ========================================
+   DIRECTORY SPECIFIC STYLES
+   ======================================== */
+
+/* Directory Container */
+.directory-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Loading State */
+.loading {
+  text-align: center;
+  padding: 4rem 2rem;
+  font-size: 1.2rem;
+  color: #666;
+}
+
+/* Error Message */
+.error-message {
+  max-width: 600px;
+  margin: 4rem auto;
+  padding: 2rem;
+  background: #fee;
+  border: 1px solid #fcc;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.error-message h2 {
+  color: #c33;
+  margin-bottom: 1rem;
+}
+
+.error-message p {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+/* Directory Header */
+.directory-header {
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.directory-header h1 {
+  margin: 0 0 1rem 0;
+  font-size: 2rem;
+  color: #333;
+}
+
+.directory-header p {
+  margin: 0;
+  color: #666;
+}
+
+/* Filter Section */
+.filter-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.filter-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.filter-btn {
+  padding: 0.5rem 1rem;
+  border: 2px solid #e0e0e0;
+  background: #fff;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: #333;
+}
+
+.filter-btn:hover {
+  border-color: #1967d2;
+  color: #1967d2;
+}
+
+.filter-btn.active {
+  background: #1967d2;
+  border-color: #1967d2;
+  color: #fff;
+}
+
+.results-count {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* Group Grid */
+.group-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+/* Group Card */
+.group-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: all 0.2s;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+}
+
+.group-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+.group-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+
+.group-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: #e8f0fe;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  color: #1967d2;
+  flex-shrink: 0;
+}
+
+.group-info {
+  flex: 1;
+}
+
+.group-name {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.25rem;
+}
+
+.group-project {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.group-status {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.group-status.status-healthy {
+  background: #e8f5e9;
+  color: #1e8e3e;
+}
+
+.group-status.status-at-risk {
+  background: #fff3e0;
+  color: #f57c00;
+}
+
+.group-status.status-critical {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.group-status.status-excellent {
+  background: #e8f0fe;
+  color: #1967d2;
+}
+
+.group-meta {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e0e0e0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.group-members {
+  font-size: 0.875rem;
+  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.group-members-icon {
+  font-size: 1rem;
+}
+
+.group-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.group-tag {
+  padding: 0.25rem 0.5rem;
+  background: #f5f5f5;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #666;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2rem;
+}
+
+.pagination-btn {
+  padding: 0.5rem 1rem;
+  border: 2px solid #e0e0e0;
+  background: #fff;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: #333;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  border-color: #1967d2;
+  color: #1967d2;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pagination-btn.active {
+  background: #1967d2;
+  border-color: #1967d2;
+  color: #fff;
+}
+
+.pagination-info {
+  padding: 0.5rem 1rem;
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* No Data Message */
+.no-data {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #666;
+  font-style: italic;
+}
+
+.no-data h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #999;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  background: #1967d2;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #1557b0;
+}
+
+/* ========================================
+   RESPONSIVE DESIGN
+   ======================================== */
+
+@media (max-width: 768px) {
+  /* Navigation */
+  .nav-container {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  /* Directory */
+  .directory-container {
+    padding: 1rem;
+  }
+
+  .directory-header {
+    padding: 1.5rem;
+  }
+
+  .directory-header h1 {
+    font-size: 1.5rem;
+  }
+
+  /* Filters */
+  .filter-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-buttons {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  /* Group Grid */
+  .group-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Group Card */
+  .group-card-header {
+    flex-direction: column;
+  }
+
+  .group-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  /* Pagination */
+  .pagination {
+    flex-wrap: wrap;
+  }
+
+  .pagination-info {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/frontend/html/directory/group-directory.html
+++ b/frontend/html/directory/group-directory.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Group Directory - Conductor Tool</title>
+
+  <!-- Stylesheets -->
+  <link rel="stylesheet" href="../../css/pages/directory/group-directory.css">
+</head>
+<body>
+  <!-- Navigation Header -->
+  <nav id="main-nav" class="main-nav">
+    <div class="nav-container">
+      <div class="nav-brand">
+        <a href="class-dashboard.html?course=test-course">Conductor Tool</a>
+      </div>
+      <div class="nav-links">
+        <a href="class-dashboard.html?course=test-course">Dashboard</a>
+        <a href="user-profile.html?user=staff-1-uuid" id="myProfileLink">My Profile</a>
+        <a href="#logout">Logout</a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Main Directory Container -->
+  <main id="directory-container" class="directory-container">
+    <!-- Directory content will be dynamically rendered here -->
+    <div class="loading">Loading groups...</div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="main-footer">
+    <div class="footer-container">
+      <p>&copy; 2025 Conductor Tool. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <!-- Scripts -->
+  <script type="module" src="../../js/pages/directory/group-directory/index.js"></script>
+</body>
+</html>

--- a/frontend/js/api/directory/mockData.js
+++ b/frontend/js/api/directory/mockData.js
@@ -10,12 +10,12 @@ export const mockData = {
     course_uuid: "course-123-uuid",
 
     // Change to "staff-1-uuid" for instructor view
-    user_uuid: "student-1-uuid",
-    // user_uuid: "staff-1-uuid",
+    // user_uuid: "student-1-uuid",
+    user_uuid: "staff-1-uuid",
 
     // Change to "instructor" or "ta" for instructor view
-    role: "student"
-    // role: "instructor"
+    // role: "student"
+    role: "instructor"
   },
 
   // Course overview data
@@ -1088,7 +1088,7 @@ export const mockData = {
         repo_url: "https://github.com/conductor-tool/iot-innovators",
         docs_url: "https://docs.example.com/iot-innovators",
         chat_url: "https://chat.example.com/iot-innovators",
-        status_health: "Needs Attention",
+        status_health: "Critical",
         status_summary: "Hardware procurement delays slowed integration tests.",
         status_updated: "2024-11-09",
         tags: ["IoT", "Embedded", "Web"]
@@ -1368,7 +1368,7 @@ export const mockData = {
         repo_url: "https://github.com/conductor-tool/design-driven",
         docs_url: "https://docs.example.com/design-driven",
         chat_url: "https://chat.example.com/design-driven",
-        status_health: "Stable",
+        status_health: "Excellent",
         status_summary: "Pilot extension ready; focusing on documentation polish.",
         status_updated: "2024-11-09",
         tags: ["Accessibility", "Browser Extensions"]

--- a/frontend/js/pages/directory/QUICK_START.md
+++ b/frontend/js/pages/directory/QUICK_START.md
@@ -54,6 +54,19 @@ View all students and staff in the course: `http://localhost:8080/html/directory
 - Shows 18 total users (15 students + 3 staff)
 - Page navigation at the bottom
 
+### Group Directory
+
+#### Group Directory Page
+View all teams/groups in the course: `http://localhost:8080/html/directory/group-directory.html?course=test-course`
+
+**Features:**
+- Paginated grid of group cards (3 per page, 2 pages total)
+- Filter by status (All, On Track, At Risk, Critical, Excellent)
+- Click any card to navigate to that group's profile
+- Shows 6 total teams with project names, member counts, and status
+- Page navigation at the bottom (Previous, 1, 2, Next)
+- Each card displays team icon, name, project name, status badge, member count, and tags
+
 ### User Profile Page
 
 #### Student Profiles (15 total)
@@ -111,7 +124,7 @@ View all students and staff in the course: `http://localhost:8080/html/directory
 - Enrollment statistics (523 students, 498 active)
 - Recent enrollments list (clickable names link to student profiles)
 - Teaching staff cards with office hours (clickable names link to profiles)
-- Navigation buttons (Class Roster, My Profile)
+- Navigation buttons (Class Roster, Group Directory, My Profile)
 
 ### User Directory (Roster):
 - Paginated grid of user cards (12 per page, 2 pages total)
@@ -129,6 +142,14 @@ View all students and staff in the course: `http://localhost:8080/html/directory
 - Staff information (office location, research interests) - for staff users only
 - Team membership cards with leader badge (links to team profile pages)
 - Group profile pages surface mission, status, meeting cadence, members, milestones, and notes.
+
+### Group Directory:
+- Paginated grid of group cards (3 per page, 2 pages total)
+- Filter buttons (All, On Track, At Risk, Critical, Excellent) with counts
+- Group cards show team icon, name, project name, status badge, member count, and tags
+- Clickable cards navigate to group profiles
+- Page navigation (Previous, 1, 2, Next)
+- Results count display
 
 ## Switching to Real API
 
@@ -152,7 +173,7 @@ When the backend is ready:
    }
    ```
 
-3. Make similar changes in `studentView.js`, `instructorView.js`, `user-profile/index.js`, `group-profile/index.js`, and `user-directory/directoryView.js`:
+3. Make similar changes in `studentView.js`, `instructorView.js`, `user-profile/index.js`, `group-profile/index.js`, `user-directory/directoryView.js`, and `group-directory/directoryView.js`:
    ```javascript
    // Change from:
    import { ... } from "../../../api/directory/directoryApiMock.js";
@@ -161,7 +182,7 @@ When the backend is ready:
    import { ... } from "../../../api/directoryApi.js";
    ```
 
-4. For `user-directory/index.js`, remove the mockData import:
+4. For `user-directory/index.js` and `group-directory/index.js`, remove the mockData import:
    ```javascript
    // Remove:
    import { mockData } from "../../../api/directory/mockData.js";
@@ -178,7 +199,9 @@ frontend/
 │   └── pages/
 │       └── directory/
 │           ├── dashboard.css          # Dashboard styles
-│           └── user-profile.css       # User profile page styles
+│           ├── user-profile.css       # User profile page styles
+│           ├── user-directory.css     # User directory/roster styles
+│           └── group-directory.css    # Group directory styles
 ├── js/
 │   ├── api/
 │   │   ├── directoryApi.js            # Real API stubs (swap in apiClient once ready)
@@ -194,6 +217,9 @@ frontend/
 │           ├── group-profile/         # Team profile feature
 │           │   ├── index.js           # Main controller
 │           │   └── profileView.js     # Profile rendering
+│           ├── group-directory/       # Group directory feature
+│           │   ├── index.js           # Main controller
+│           │   └── directoryView.js   # Directory rendering with pagination
 │           ├── user-profile/          # User profile feature
 │           │   ├── index.js           # Main controller
 │           │   └── profileView.js     # Profile rendering
@@ -204,6 +230,7 @@ frontend/
     └── directory/
         ├── class-dashboard.html       # Dashboard HTML page
         ├── group-profile.html         # Group profile HTML page
+        ├── group-directory.html       # Group directory HTML page
         ├── user-profile.html          # User profile HTML page
         └── user-directory.html        # User directory/roster HTML page
 ```
@@ -214,11 +241,13 @@ Just edit the files and refresh your browser:
 
 - Edit Dashboard CSS: `frontend/css/pages/directory/dashboard.css`
 - Edit Profile CSS: `frontend/css/pages/directory/user-profile.css`
-- Edit Directory CSS: `frontend/css/pages/directory/user-directory.css`
+- Edit User Directory CSS: `frontend/css/pages/directory/user-directory.css`
+- Edit Group Directory CSS: `frontend/css/pages/directory/group-directory.css`
 - Edit Mock Data: `frontend/js/api/directory/mockData.js`
 - Edit Dashboard Views: `frontend/js/pages/directory/class-dashboard/*.js`
 - Edit Profile View: `frontend/js/pages/directory/user-profile/profileView.js`
-- Edit Directory View: `frontend/js/pages/directory/user-directory/directoryView.js`
+- Edit User Directory View: `frontend/js/pages/directory/user-directory/directoryView.js`
+- Edit Group Directory View: `frontend/js/pages/directory/group-directory/directoryView.js`
 - Edit HTML: `frontend/html/directory/*.html`
 
 **No build step required!** The HTML files reference JS and CSS directly with relative paths.

--- a/frontend/js/pages/directory/class-dashboard/instructorView.js
+++ b/frontend/js/pages/directory/class-dashboard/instructorView.js
@@ -185,6 +185,10 @@ function renderNavigationButtons(courseUuid) {
         <span class="icon">👥</span>
         <span class="label">Class Roster</span>
       </a>
+      <a href="group-directory.html?course=${courseUuid}" class="nav-btn">
+        <span class="icon">🏢</span>
+        <span class="label">Group Directory</span>
+      </a>
       <a href="user-profile.html?user=staff-1-uuid" class="nav-btn">
         <span class="icon">👤</span>
         <span class="label">My Profile</span>

--- a/frontend/js/pages/directory/group-directory/directoryView.js
+++ b/frontend/js/pages/directory/group-directory/directoryView.js
@@ -1,0 +1,292 @@
+/**
+ * Group Directory View
+ * Renders paginated group/team cards with filtering by status
+ */
+
+import { getCourseTeams } from "../../../api/directory/directoryApiMock.js";
+
+// State management for pagination and filtering
+const currentState = {
+  courseUuid: null,
+  page: 1,
+  limit: 3,
+  filter: "all", // "all", "healthy", "at-risk", "critical", "excellent"
+  totalCount: 0,
+  totalPages: 0
+};
+
+/**
+ * Render directory header
+ * @param {string} courseName - Course name
+ * @param {number} totalCount - Total number of teams
+ * @returns {string} HTML string
+ */
+function renderHeader(courseName, totalCount) {
+  return `
+    <div class="directory-header">
+      <h1>Group Directory</h1>
+      <p>${courseName} - ${totalCount} ${totalCount === 1 ? "team" : "teams"}</p>
+    </div>
+  `;
+}
+
+/**
+ * Render filter buttons
+ * @param {Object} counts - Team counts by status
+ * @returns {string} HTML string
+ */
+function renderFilters(counts) {
+  const filters = [
+    { value: "all", label: "All", count: counts.all },
+    { value: "healthy", label: "On Track", count: counts.healthy },
+    { value: "at-risk", label: "At Risk", count: counts.at_risk },
+    { value: "critical", label: "Critical", count: counts.critical },
+    { value: "excellent", label: "Excellent", count: counts.excellent }
+  ];
+
+  const filterButtons = filters.map(filter => {
+    const activeClass = currentState.filter === filter.value ? "active" : "";
+    return `
+      <button
+        class="filter-btn ${activeClass}"
+        data-filter="${filter.value}">
+        ${filter.label} (${filter.count})
+      </button>
+    `;
+  }).join("");
+
+  const startIndex = (currentState.page - 1) * currentState.limit + 1;
+  const endIndex = Math.min(currentState.page * currentState.limit, currentState.totalCount);
+  const resultsText = currentState.totalCount > 0
+    ? `Showing ${startIndex}-${endIndex} of ${currentState.totalCount}`
+    : "No results";
+
+  return `
+    <div class="filter-section">
+      <div class="filter-buttons">
+        ${filterButtons}
+      </div>
+      <div class="results-count">${resultsText}</div>
+    </div>
+  `;
+}
+
+/**
+ * Render group card
+ * @param {Object} team - Team data
+ * @returns {string} HTML string
+ */
+function renderGroupCard(team) {
+  // Determine status class
+  let statusClass = "status-healthy";
+  if (team.status_health === "At Risk") {
+    statusClass = "status-at-risk";
+  } else if (team.status_health === "Critical") {
+    statusClass = "status-critical";
+  } else if (team.status_health === "Excellent") {
+    statusClass = "status-excellent";
+  }
+
+  // Render tags (show up to 2)
+  const tagsHtml = team.tags && team.tags.length > 0
+    ? team.tags.slice(0, 2).map(tag => `<span class="group-tag">${tag}</span>`).join("")
+    : "";
+
+  return `
+    <a href="group-profile.html?team=${team.team_uuid}" class="group-card">
+      <div class="group-card-header">
+        <div class="group-icon">👥</div>
+        <div class="group-info">
+          <div class="group-name">${team.team_name}</div>
+          <div class="group-project">${team.project_name || "No project assigned"}</div>
+          <span class="group-status ${statusClass}">${team.status_health}</span>
+        </div>
+      </div>
+      <div class="group-meta">
+        <div class="group-members">
+          <span class="group-members-icon">🧑‍🤝‍🧑</span>
+          <span>${team.member_count} ${team.member_count === 1 ? "member" : "members"}</span>
+        </div>
+        ${tagsHtml ? `<div class="group-tags">${tagsHtml}</div>` : ""}
+      </div>
+    </a>
+  `;
+}
+
+/**
+ * Render group grid
+ * @param {Array} teams - List of teams
+ * @returns {string} HTML string
+ */
+function renderGroupGrid(teams) {
+  if (!teams || teams.length === 0) {
+    return `
+      <div class="no-data">
+        <h3>No teams found</h3>
+        <p>Try adjusting your filters</p>
+      </div>
+    `;
+  }
+
+  const cards = teams.map(team => renderGroupCard(team)).join("");
+
+  return `
+    <div class="group-grid">
+      ${cards}
+    </div>
+  `;
+}
+
+/**
+ * Render pagination controls
+ * @returns {string} HTML string
+ */
+function renderPagination() {
+  if (currentState.totalPages <= 1) {
+    return ""; // Don't show pagination if only one page
+  }
+
+  const pages = [];
+  const maxVisiblePages = 5;
+  let startPage = Math.max(1, currentState.page - Math.floor(maxVisiblePages / 2));
+  const endPage = Math.min(currentState.totalPages, startPage + maxVisiblePages - 1);
+
+  // Adjust start if we're near the end
+  if (endPage - startPage < maxVisiblePages - 1) {
+    startPage = Math.max(1, endPage - maxVisiblePages + 1);
+  }
+
+  // Previous button
+  const prevDisabled = currentState.page === 1 ? "disabled" : "";
+  pages.push(`
+    <button class="pagination-btn" data-page="${currentState.page - 1}" ${prevDisabled}>
+      « Previous
+    </button>
+  `);
+
+  // First page + ellipsis
+  if (startPage > 1) {
+    pages.push(`
+      <button class="pagination-btn" data-page="1">1</button>
+    `);
+    if (startPage > 2) {
+      pages.push(`
+        <span class="pagination-info">...</span>
+      `);
+    }
+  }
+
+  // Page numbers
+  for (let i = startPage; i <= endPage; i++) {
+    const activeClass = i === currentState.page ? "active" : "";
+    pages.push(`
+      <button class="pagination-btn ${activeClass}" data-page="${i}">
+        ${i}
+      </button>
+    `);
+  }
+
+  // Ellipsis + last page
+  if (endPage < currentState.totalPages) {
+    if (endPage < currentState.totalPages - 1) {
+      pages.push(`
+        <span class="pagination-info">...</span>
+      `);
+    }
+    pages.push(`
+      <button class="pagination-btn" data-page="${currentState.totalPages}">
+        ${currentState.totalPages}
+      </button>
+    `);
+  }
+
+  // Next button
+  const nextDisabled = currentState.page === currentState.totalPages ? "disabled" : "";
+  pages.push(`
+    <button class="pagination-btn" data-page="${currentState.page + 1}" ${nextDisabled}>
+      Next »
+    </button>
+  `);
+
+  return `
+    <div class="pagination">
+      ${pages.join("")}
+    </div>
+  `;
+}
+
+/**
+ * Setup event listeners for filters and pagination
+ * @param {HTMLElement} container - Directory container
+ */
+function setupEventListeners(container) {
+  // Filter button listeners
+  const filterButtons = container.querySelectorAll(".filter-btn");
+  filterButtons.forEach(button => {
+    button.addEventListener("click", async () => {
+      currentState.filter = button.dataset.filter;
+      currentState.page = 1; // Reset to page 1 when filter changes
+      await renderGroupDirectory(currentState.courseUuid, container);
+    });
+  });
+
+  // Pagination button listeners
+  const paginationButtons = container.querySelectorAll(".pagination-btn");
+  paginationButtons.forEach(button => {
+    button.addEventListener("click", async () => {
+      if (button.disabled) return;
+      currentState.page = parseInt(button.dataset.page);
+      await renderGroupDirectory(currentState.courseUuid, container);
+      // Scroll to top of page
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  });
+}
+
+/**
+ * Render complete group directory view
+ * @param {string} courseUuid - Course UUID
+ * @param {HTMLElement} container - Container element to render into
+ */
+export async function renderGroupDirectory(courseUuid, container) {
+  try {
+    // Update state
+    currentState.courseUuid = courseUuid;
+
+    // Show loading state
+    container.innerHTML = "<div class=\"loading\">Loading groups...</div>";
+
+    // Fetch team data with pagination and filter
+    const teamsData = await getCourseTeams(
+      courseUuid,
+      currentState.page,
+      currentState.limit,
+      currentState.filter
+    );
+
+    // Update state with response data
+    currentState.totalCount = teamsData.total_count;
+    currentState.totalPages = teamsData.total_pages;
+
+    // Render the complete directory
+    container.innerHTML = `
+      <div class="group-directory">
+        ${renderHeader(teamsData.course_name, teamsData.total_count)}
+        ${renderFilters(teamsData.counts)}
+        ${renderGroupGrid(teamsData.teams)}
+        ${renderPagination()}
+      </div>
+    `;
+
+    // Setup event listeners
+    setupEventListeners(container);
+
+  } catch (error) {
+    container.innerHTML = `
+      <div class="error-message">
+        <h2>Error Loading Groups</h2>
+        <p>${error.message || "Failed to load groups. Please try again later."}</p>
+      </div>
+    `;
+  }
+}

--- a/frontend/js/pages/directory/group-directory/index.js
+++ b/frontend/js/pages/directory/group-directory/index.js
@@ -1,0 +1,77 @@
+/**
+ * Group Directory Page Controller
+ * Main entry point for the group directory page
+ * Displays paginated list of teams/groups with filtering
+ */
+
+import { renderGroupDirectory } from "./directoryView.js";
+import { mockData } from "../../../api/directory/mockData.js";
+
+/**
+ * Get course UUID from URL parameters
+ * @returns {string|null} Course UUID or null if not found
+ */
+function getCourseUuidFromUrl() {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get("course");
+}
+
+/**
+ * Update navigation bar "My Profile" link based on user role
+ * Uses direct mockData access for immediate update without delay
+ */
+function updateNavigationLinks() {
+  const myProfileLink = document.getElementById("myProfileLink");
+
+  if (myProfileLink) {
+    // Get role data directly from mockData (no async delay)
+    const roleData = mockData.userRole;
+    const userUuid = roleData.user_uuid || (roleData.role === "student" ? "student-1-uuid" : "staff-1-uuid");
+    myProfileLink.href = `user-profile.html?user=${userUuid}`;
+  }
+}
+
+/**
+ * Initialize the group directory page
+ * Sets up pagination and filtering
+ */
+async function initDirectory() {
+  const container = document.getElementById("directory-container");
+
+  if (!container) {
+    return;
+  }
+
+  // Update navigation bar immediately without delay
+  updateNavigationLinks();
+
+  // Get course UUID from URL
+  const courseUuid = getCourseUuidFromUrl();
+
+  if (!courseUuid) {
+    container.innerHTML = `
+      <div class="error-message">
+        <h2>Invalid Course</h2>
+        <p>No course specified. Please select a course from the <a href="class-dashboard.html?course=test-course">dashboard</a>.</p>
+      </div>
+    `;
+    return;
+  }
+
+  try {
+    // Render the directory with initial state (page 1, filter all)
+    await renderGroupDirectory(courseUuid, container);
+
+  } catch (error) {
+    container.innerHTML = `
+      <div class="error-message">
+        <h2>Error Loading Groups</h2>
+        <p>${error.message || "Failed to load groups. Please try again later."}</p>
+        <a href="class-dashboard.html?course=${courseUuid}" class="btn btn-primary">Back to Dashboard</a>
+      </div>
+    `;
+  }
+}
+
+// Initialize directory when DOM is ready
+document.addEventListener("DOMContentLoaded", initDirectory);


### PR DESCRIPTION
## Summary
Implements a Group Directory page for instructors to view and manage all teams in a course. This feature adds a paginated directory of all groups with filtering capabilities by team status, accessible from the instructor dashboard.

## Related Issues / Tickets
Closes #42 

## Changes Introduced
- **Pagination**: 3 teams per page with page navigation controls
- **Status Filtering**: Filter by All, On Track, At Risk, Critical, Excellent
- **Team Cards**: Display team icon, name, project name, status badge, member count, and tags
- **Navigation**: Each card links to the corresponding group profile page

## Testing Instructions
Check [link](https://github.com/CSE210-fa25-team07/conductor-tool/blob/32-class-directory/frontend/js/pages/directory/QUICK_START.md) for details.

## Screenshots / Demos (if applicable)
<img width="1388" height="794" alt="image" src="https://github.com/user-attachments/assets/ae8f7ce3-c565-46ee-8fcc-f1904942a00b" />
<img width="1324" height="639" alt="image" src="https://github.com/user-attachments/assets/035f6d9f-b00d-4c1d-8751-0318bc3243b5" />

